### PR TITLE
Add display product ID 0xC112

### DIFF
--- a/DisplayProductID-c112
+++ b/DisplayProductID-c112
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DisplayProductID</key>
+	<integer>49426</integer>
+	<key>DisplayProductName</key>
+	<string>Qualia</string>
+	<key>DisplayVendorID</key>
+	<integer>1552</integer>
+    <key>IOGFlags</key>
+	<integer>4</integer>
+	<key>scale-resolutions</key>
+	<array>
+		<data>AAACgAAAAeAAAAAB</data>
+		<data>AAADIAAAAlgAAAAB</data>
+		<data>AAAEAAAAAoAAAAAB</data>
+		<data>AAAEAAAAAwAAAAAB</data>
+		<data>AAAIAAAABQAAAAAJAIAAAA==</data>
+		<data>AAAIAAAABgAAAAAJAIAAAA==</data>
+	</array>
+</dict>
+</plist>

--- a/install.command
+++ b/install.command
@@ -2,6 +2,6 @@
 
 pushd `dirname $0` > /dev/null
 pwd
-sudo cp DisplayProductID-c111 /System/Library/Displays/Overrides/DisplayVendorID-610
+sudo cp DisplayProductID-* /System/Library/Displays/Overrides/DisplayVendorID-610
 popd > /dev/null
 


### PR DESCRIPTION
I installed this and it didn't work with my Adafruit Qualia display. Further inspection revealed the product ID of my display was 0xC112 not 0xC111. This might be a difference in the newer panels. I've created a copy of the override file for this display ID and it works fine with my display.

Thanks.
